### PR TITLE
setup: API app entry-point registration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,9 @@ setup(
         'invenio_base.apps': [
             'cds_sorenson = cds_sorenson:CDSSorenson',
         ],
+        'invenio_base.api_apps': [
+            'cds_sorenson = cds_sorenson:CDSSorenson',
+        ],
         'invenio_i18n.translations': [
             'messages = cds_sorenson',
         ],


### PR DESCRIPTION
- Fixes issue, which occured when the Sorenson API was called from an
  API app instead of a normal one. Now the Sorenson app is registared as
  an API app as well.

Signed-off-by: Orestis Melkonian melkon.or@gmail.com
