### PR TITLE
api: output folder as argument

### DIFF
--- a/cds_sorenson/error.py
+++ b/cds_sorenson/error.py
@@ -30,8 +30,10 @@ from __future__ import absolute_import, print_function
 class SorensonError(Exception):
     """Base class for exceptions in this module."""
 
-    def _init_(self, error_message):
+    def __init__(self, error_message=''):
+        """Initialize exception with error message."""
         self.error_message = error_message
 
-    def _str_(self):
+    def __str__(self):
+        """Show error message."""
         return self.error_message


### PR DESCRIPTION
* Makes it possible to specify the output folder independently for each
  request, instead of relying on the configuration variable.

* Removes batch operations.

* Fixes some minor typos and error handling.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>