### PR TITLE
config: add 5 more presets

### DIFF
--- a/cds_sorenson/config.py
+++ b/cds_sorenson/config.py
@@ -96,7 +96,37 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 386,
             'total_bitrate': 450,
             'frame_rate': 15,
-            'preset_id': '55f586de-15a0-45cd-bd30-bb6cf5bfe2b8'})])),
+            'preset_id': '55f586de-15a0-45cd-bd30-bb6cf5bfe2b8'}),
+        ('2160p', {
+            'width': 3840,
+            'height': 2160,
+            'audio_bitrate': 128,
+            'video_bitrate': 19872,
+            'total_bitrate': 20000,
+            'frame_rate': 25,
+            'preset_id': '71d9865f-779d-4421-b62e-df93135b41c6'}),
+        ('2160ph265', {
+            # Different codec: H.265 - for download only - no SMIL file
+            'width': 3840,
+            'height': 2160,
+            'audio_bitrate': 128,
+            'video_bitrate': 19872,
+            'total_bitrate': 20000,
+            'frame_rate': 25,
+            'preview': False,
+            'smil': False,
+            'preset_id': 'a0f072d3-c319-47e1-bdc4-787ad10be63c'}),
+        ('1080ph265', {
+            # Different codec: H.265 - for download only - no SMIL file
+            'width': 1920,
+            'height': 1080,
+            'audio_bitrate': 128,
+            'video_bitrate': 5872,
+            'total_bitrate': 6000,
+            'frame_rate': 25,
+            'preview': False,
+            'smil': False,
+            'preset_id': 'fd15cb19-6750-4872-a82b-e4625b842c30'})])),
     ('4:3', OrderedDict([
         ('360p', {
             'width': 480,
@@ -180,7 +210,7 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'frame_rate': 15,
             'preset_id': '4ee80866-a960-41a7-887d-50041e991300'})])),
     ('20:9', OrderedDict([
-          ('240p', {
+        ('240p', {
             'width': 534,
             'height': 240,
             'audio_bitrate': 64,
@@ -228,7 +258,26 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 386,
             'total_bitrate': 450,
             'frame_rate': 15,
-            'preset_id': 'aa20a566-31ce-4e9c-b0ab-edc6b5f4146d'})])),
+            'preset_id': 'aa20a566-31ce-4e9c-b0ab-edc6b5f4146d'}),
+        ('2160p', {
+            'width': 4096,
+            'height': 2160,
+            'audio_bitrate': 128,
+            'video_bitrate': 19872,
+            'total_bitrate': 20000,
+            'frame_rate': 25,
+            'preset_id': 'beed7d75-4b78-46b7-9645-1a30413735ba'}),
+        ('2160ph265', {
+            # Different codec H.265 - for preview only - no SMIL file
+            'width': 4096,
+            'height': 2160,
+            'audio_bitrate': 128,
+            'video_bitrate': 19872,
+            'total_bitrate': 20000,
+            'frame_rate': 25,
+            'preview': False,
+            'smil': False,
+            'preset_id': 'bddf6b9f-c15a-4333-9809-bdb9a244056b'})])),
     ('64:35', OrderedDict([
         ('360p', {
             'width': 658,
@@ -292,6 +341,12 @@ CDS_SORENSON_PRESETS = OrderedDict([
 
 The first preset of each list is the previewer (slave small enough to be
 quickly created but not too small to not be very pixelated).
+
+Optional parameters for each preset configuration:
+preview: specifies if the file should be available for preview or only for
+    downloading (default is True)
+smil: specifies if this file should be added to the SMIL file
+    (default is True)
 """
 
 CDS_SORENSON_NAME_GENERATOR = 'cds_sorenson.utils.name_generator'

--- a/cds_sorenson/config.py
+++ b/cds_sorenson/config.py
@@ -64,6 +64,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 836,
             'total_bitrate': 900,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': 'dc2187a3-8f64-4e73-b458-7370a88d92d7'}),
         ('1080p', {
             'width': 1920,
@@ -72,6 +74,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5872,
             'total_bitrate': 6000,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'd9683573-f1c6-46a4-9181-d6048b2db305'}),
         ('720p', {
             'width': 1280,
@@ -80,6 +84,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 2672,
             'total_bitrate': 2800,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': '79e9bde9-adcc-4603-b686-c7e2cb2d73d2'}),
         ('480p', {
             'width': 854,
@@ -88,6 +94,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 1436,
             'total_bitrate': 1500,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '9bd7c93f-88fa-4e59-a811-c81f4b0543db'}),
         ('240p', {
             'width': 432,
@@ -96,6 +104,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 386,
             'total_bitrate': 450,
             'frame_rate': 15,
+            'smil': True,
+            'download': False,
             'preset_id': '55f586de-15a0-45cd-bd30-bb6cf5bfe2b8'}),
         ('2160p', {
             'width': 3840,
@@ -104,6 +114,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 19872,
             'total_bitrate': 20000,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': '71d9865f-779d-4421-b62e-df93135b41c6'}),
         ('2160ph265', {
             # Different codec: H.265 - for download only - no SMIL file
@@ -113,8 +125,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 19872,
             'total_bitrate': 20000,
             'frame_rate': 25,
-            'preview': False,
             'smil': False,
+            'download': True,
             'preset_id': 'a0f072d3-c319-47e1-bdc4-787ad10be63c'}),
         ('1080ph265', {
             # Different codec: H.265 - for download only - no SMIL file
@@ -124,8 +136,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5872,
             'total_bitrate': 6000,
             'frame_rate': 25,
-            'preview': False,
             'smil': False,
+            'download': True,
             'preset_id': 'fd15cb19-6750-4872-a82b-e4625b842c30'})])),
     ('4:3', OrderedDict([
         ('360p', {
@@ -135,6 +147,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 686,
             'total_bitrate': 750,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '2b048f02-eca3-4e68-8eb6-f82375b1d15b'}),
         ('1080p', {
             'width': 1440,
@@ -143,6 +157,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5372,
             'total_bitrate': 5500,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': '216d5415-7d11-471c-bd06-0c013f657494'}),
         ('720p', {
             'width': 960,
@@ -151,6 +167,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 2372,
             'total_bitrate': 2500,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': '28ec9d35-00f3-400b-a955-dfb52f9d45ae'}),
         ('480p', {
             'width': 640,
@@ -159,6 +177,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 1136,
             'total_bitrate': 1200,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '7b7a3cae-2ca1-4b80-b756-b01fbdd46f78'}),
         ('240p', {
             'width': 320,
@@ -167,6 +187,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 286,
             'total_bitrate': 350,
             'frame_rate': 15,
+            'smil': True,
+            'download': False,
             'preset_id': 'a3214691-7f2b-47ff-a868-7bce6f5dbb7c'})])),
     ('3:2', OrderedDict([
         ('360p', {
@@ -176,6 +198,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 736,
             'total_bitrate': 800,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '52e22f47-b459-44a1-b41e-0219fe7d06c3'}),
         ('1080p', {
             'width': 1620,
@@ -184,6 +208,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5472,
             'total_bitrate': 5600,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'a3784f67-777a-42bc-8aa4-1a585d49276b'}),
         ('720p', {
             'width': 1080,
@@ -192,6 +218,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 2472,
             'total_bitrate': 2600,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'c3a1f9b0-b1dd-4987-b2b1-cd7936f114ed'}),
         ('480p', {
             'width': 720,
@@ -200,6 +228,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 1236,
             'total_bitrate': 1300,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': 'e23bc6dd-e879-4e62-8692-48f6c9dd5bcc'}),
         ('240p', {
             'width': 360,
@@ -208,6 +238,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 316,
             'total_bitrate': 380,
             'frame_rate': 15,
+            'smil': True,
+            'download': False,
             'preset_id': '4ee80866-a960-41a7-887d-50041e991300'})])),
     ('20:9', OrderedDict([
         ('240p', {
@@ -217,6 +249,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 316,
             'total_bitrate': 380,
             'frame_rate': 15,
+            'smil': True,
+            'download': False,
             'preset_id': 'aba0570f-51de-4ad7-9af4-2ece661ddc7f'})])),
     ('256:135', OrderedDict([
         ('360p', {
@@ -226,6 +260,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 836,
             'total_bitrate': 900,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '89aeb4af-3d72-442d-8bc9-32b54244526a'}),
         ('1080p', {
             'width': 2040,
@@ -234,6 +270,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5872,
             'total_bitrate': 6000,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': '4e2d0677-317d-4aa3-9228-bdca00005f9f'}),
         ('720p', {
             'width': 1360,
@@ -242,6 +280,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 2672,
             'total_bitrate': 2800,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'dac209c0-1d2b-4cef-907d-882c30407690'}),
         ('480p', {
             'width': 906,
@@ -250,6 +290,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 1436,
             'total_bitrate': 1500,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '6da3e029-9cf4-46e6-8e5a-98dd4eddbe60'}),
         ('240p', {
             'width': 454,
@@ -258,6 +300,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 386,
             'total_bitrate': 450,
             'frame_rate': 15,
+            'smil': True,
+            'download': False,
             'preset_id': 'aa20a566-31ce-4e9c-b0ab-edc6b5f4146d'}),
         ('2160p', {
             'width': 4096,
@@ -266,6 +310,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 19872,
             'total_bitrate': 20000,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'beed7d75-4b78-46b7-9645-1a30413735ba'}),
         ('2160ph265', {
             # Different codec H.265 - for preview only - no SMIL file
@@ -275,8 +321,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 19872,
             'total_bitrate': 20000,
             'frame_rate': 25,
-            'preview': False,
             'smil': False,
+            'download': True,
             'preset_id': 'bddf6b9f-c15a-4333-9809-bdb9a244056b'})])),
     ('64:35', OrderedDict([
         ('360p', {
@@ -286,6 +332,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 836,
             'total_bitrate': 900,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': 'a1579abc-ac74-4273-9671-d758cb3c413e'}),
         ('1080p', {
             'width': 1976,
@@ -294,6 +342,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5872,
             'total_bitrate': 6000,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'b4426e61-60fc-44ef-8281-8e838a107f8e'})])),
     ('2:1', OrderedDict([
         ('360p', {
@@ -303,6 +353,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 836,
             'total_bitrate': 900,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '9ad2850f-40f3-45cd-9ab5-d12925294a17'}),
         ('1024p', {
             'width': 2048,
@@ -311,6 +363,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 5872,
             'total_bitrate': 6000,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': '0149f7e7-e286-4604-a80a-23021b7d71b4'}),
         ('720p', {
             'width': 1440,
@@ -319,6 +373,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 2672,
             'total_bitrate': 2800,
             'frame_rate': 25,
+            'smil': True,
+            'download': True,
             'preset_id': 'b219ac63-00b4-4fef-8192-346fcf0cfe24'}),
         ('480p', {
             'width': 960,
@@ -327,6 +383,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 1436,
             'total_bitrate': 1500,
             'frame_rate': 25,
+            'smil': True,
+            'download': False,
             'preset_id': '120ebe70-1862-4dce-b4fb-6ddfc7b7f364'}),
         ('240p', {
             'width': 480,
@@ -335,6 +393,8 @@ CDS_SORENSON_PRESETS = OrderedDict([
             'video_bitrate': 386,
             'total_bitrate': 450,
             'frame_rate': 15,
+            'smil': True,
+            'download': False,
             'preset_id': 'd910e3a5-5925-498f-8ce7-1c36e35c0d12'})]))
 ])
 """List of presets available on Sorenson server.
@@ -343,10 +403,9 @@ The first preset of each list is the previewer (slave small enough to be
 quickly created but not too small to not be very pixelated).
 
 Optional parameters for each preset configuration:
-preview: specifies if the file should be available for preview or only for
-    downloading (default is True)
-smil: specifies if this file should be added to the SMIL file
-    (default is True)
+smil: specifies if this file should be added to the SMIL file.
+download: specifies if this file should be shown in the list of downloadable
+    formats.
 """
 
 CDS_SORENSON_NAME_GENERATOR = 'cds_sorenson.utils.name_generator'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,12 +22,13 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+"""Doc conf."""
+
 from __future__ import print_function
 
 import os
 
 import sphinx.environment
-
 
 # -- General configuration ------------------------------------------------
 
@@ -75,7 +76,9 @@ author = u'CERN'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', 'cds_sorenson', 'version.py'), 'rt') as fp:
+with open(os.path.join(os.path.dirname(__file__), '..',
+                       'cds_sorenson', 'version.py'),
+                    'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=cds_sorenson --cov-report=term-missing
+pep8ignore = docs/conf.py ALL
+addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=cds_sorenson --cov-report=term-missing docs tests cds_sorenson

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,9 +24,8 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
-pydocstyle cds_sorenson tests && \
+pydocstyle cds_sorenson tests docs && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,6 @@ output-dir = cds_sorenson/translations/
 [update_catalog]
 input-file = cds_sorenson/translations/messages.pot
 output-dir = cds_sorenson/translations/
+
+[pydocstyle]
+add_ignore = D401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ from cds_sorenson import CDSSorenson
 
 @pytest.fixture()
 def config():
-    """Custom config for testing purposes."""
+    """Config for testing purposes."""
     return dict(
         TESTING=True
     )
@@ -56,13 +56,13 @@ def app(config):
 
 @pytest.fixture()
 def start_response():
-    """Example response when starting new encoding job."""
+    """Return response from starting a new encoding job."""
     return u'{"JobId":"1234-2345-abcd"}'
 
 
 @pytest.fixture()
 def running_job_status_response():
-    """Example response when checking the status of running encoding job."""
+    """Return response from checking the status of running encoding job."""
     return u"""{
         "EncodeServerId":null,
         "JobId":"11111111-aaaa",
@@ -97,7 +97,7 @@ def running_job_status_response():
 
 @pytest.fixture()
 def finished_job_status_response():
-    """Example response when checking the status of finished encoding job."""
+    """Return response from checking the status of finished encoding job."""
     return u"""{
        "TimeSubmittedIso8601":"2016-10-19T12:30:12.0000000Z",
        "PercentCompleteOverall":100,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,6 +194,9 @@ def test_get_presets_by_aspect_ratio(app):
         '79e9bde9-adcc-4603-b686-c7e2cb2d73d2',
         '9bd7c93f-88fa-4e59-a811-c81f4b0543db',
         '55f586de-15a0-45cd-bd30-bb6cf5bfe2b8',
+        '71d9865f-779d-4421-b62e-df93135b41c6',
+        'a0f072d3-c319-47e1-bdc4-787ad10be63c',
+        'fd15cb19-6750-4872-a82b-e4625b842c30',
     ]
 
 
@@ -208,7 +211,9 @@ def test_available_aspect_ratios(app):
 def test_available_preset_qualities(app):
     """Test `get_available_preset_qualities` function."""
     assert get_available_preset_qualities() == ['360p', '1080p', '720p',
-                                                '480p', '240p', '1024p']
+                                                '480p', '240p', '2160p',
+                                                '2160ph265', '1080ph265',
+                                                '1024p']
 
 
 def test_get_preset_id(app):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -237,3 +237,9 @@ def test_get_preset_info(app):
                 app.config['CDS_SORENSON_PRESETS'][aspect_ratio].keys():
             assert all([key in get_preset_info(aspect_ratio, preset_quality)
                         for key in info_keys])
+
+
+def test_no_smil_config_option(app):
+    """Test that some formats should not be added to the SMIL file."""
+    assert not get_preset_info('16:9', '1080ph265').get('smil')
+    assert get_preset_info('16:9', '1080p').get('smil')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,5 +156,7 @@ def test_get_preset_config(app):
         'video_bitrate': 836,
         'total_bitrate': 900,
         'frame_rate': 25,
+        'smil': True,
+        'download': False,
         'preset_id': 'dc2187a3-8f64-4e73-b458-7370a88d92d7',
     }


### PR DESCRIPTION
* Adds five new presets. (addresses CERNDocumentServer/cds#814)

* Adds the parameter for SMIL generation and for download file.
  (closes #22)

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>
Co-Authored-By: Leonardo Rossi <leonardo.r@cern.ch>