### PR TITLE
api: add maximum height and/or width options

### DIFF
--- a/cds_sorenson/error.py
+++ b/cds_sorenson/error.py
@@ -63,3 +63,22 @@ class InvalidResolutionError(SorensonError):
         """Error message."""
         return 'Aspect ratio "{0}" does not support resolution {1}.'.format(
             self.aspect_ratio, self.resolution)
+
+
+class TooHighResolutionError(SorensonError):
+    """The resolution is over the required maximum."""
+
+    def __init__(self, aspect_ratio, max_height, max_width, height, width):
+        """Initialize exception."""
+        self._aspect_ratio = aspect_ratio
+        self._max_height = max_height
+        self._max_weight = max_width
+        self._height = height
+        self._width = width
+
+    def __str__(self):
+        """Error message."""
+        return ('Aspect ratio "{0}" resolution {1}x{2} is higher than the '
+                'maximum resolution accepted {3}x{4}.').format(
+                    self._aspect_ratio, self._width, self._height,
+                    self._max_weight, self._max_height)


### PR DESCRIPTION
* Adds maximum height and/or width for videos.
  (addresses CERNDocumentServer/cds#949)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>