### PR TITLE
release: v0.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,6 @@
 Changes
 =======
 
-Version 0.1.0 (released 2017-08-18)
+Version 0.1.1 (released 2017-08-18)
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 =====================
- cds-sorenson v0.1.0
+ cds-sorenson v0.1.1
 =====================
 
-cds-sorenson v0.1.0 was released on August 18, 2017.
+cds-sorenson v0.1.1 was released on August 18, 2017.
 
 About
 -----
@@ -17,7 +17,7 @@ What's new
 Installation
 ------------
 
-   $ pip install cds-sorenson==0.1.0
+   $ pip install cds-sorenson==0.1.1
 
 Documentation
 -------------

--- a/cds_sorenson/version.py
+++ b/cds_sorenson/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>